### PR TITLE
feat: add experience cloud community

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,7 +1,7 @@
 {
   "orgName": "freed company",
   "edition": "Developer",
-  "features": ["EnableSetPasswordInApi"],
+  "features": ["EnableSetPasswordInApi", "Communities"],
   "settings": {
     "lightningExperienceSettings": {
       "enableS1DesktopEnabled": true

--- a/docs/community-activation.md
+++ b/docs/community-activation.md
@@ -1,0 +1,27 @@
+# Community Activation Guide
+
+Follow these steps to activate the Community site and make it available to external users.
+
+1. **Deploy the metadata**
+   ```bash
+   sf project deploy start --source-path force-app/main/default/experiences
+   ```
+
+2. **Assign permissions**
+   Assign the community permission set to external users:
+   ```bash
+   sf org assign permset --name Community_User --target-org <username>
+   ```
+
+3. **Publish the community**
+   ```bash
+   sf community publish --name Community --target-org <username>
+   ```
+
+4. **Activate the site**
+   Ensure the community is activated from the Experience Cloud admin console or via the command line:
+   ```bash
+   sf community activate --name Community --target-org <username>
+   ```
+
+Replace `<username>` with the authenticated org username used for development.

--- a/force-app/main/default/experiences/Community.network-meta.xml
+++ b/force-app/main/default/experiences/Community.network-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Network xmlns="http://soap.sforce.com/2006/04/metadata">
+  <description>NextGenENOS Community network</description>
+  <status>UnderConstruction</status>
+</Network>

--- a/force-app/main/default/experiences/Community.site-meta.xml
+++ b/force-app/main/default/experiences/Community.site-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Site xmlns="http://soap.sforce.com/2006/04/metadata">
+  <label>Community</label>
+  <description>NextGenENOS Experience Cloud site</description>
+  <status>Inactive</status>
+</Site>

--- a/force-app/main/default/experiences/Community/config/main.json
+++ b/force-app/main/default/experiences/Community/config/main.json
@@ -1,0 +1,6 @@
+{
+  "defaultRoute": "home",
+  "navigationMenu": "navigationMenu",
+  "theme": "theme",
+  "themeLayoutType": "Inner"
+}

--- a/force-app/main/default/experiences/Community/navigations/navigationMenu.json
+++ b/force-app/main/default/experiences/Community/navigations/navigationMenu.json
@@ -1,0 +1,7 @@
+{
+  "navigationMenuItems": [
+    { "id": "catalogNav", "label": "Product Catalog", "type": "InternalLink", "target": "productCatalog" },
+    { "id": "quotesNav", "label": "My Quotes", "type": "InternalLink", "target": "myQuotes" },
+    { "id": "ordersNav", "label": "Order History", "type": "InternalLink", "target": "orderHistory" }
+  ]
+}

--- a/force-app/main/default/experiences/Community/routes/home.json
+++ b/force-app/main/default/experiences/Community/routes/home.json
@@ -1,0 +1,7 @@
+{
+  "id": "home",
+  "label": "Home",
+  "routeType": "Home",
+  "urlPrefix": "",
+  "activeViewId": "home"
+}

--- a/force-app/main/default/experiences/Community/routes/myQuotes.json
+++ b/force-app/main/default/experiences/Community/routes/myQuotes.json
@@ -1,0 +1,7 @@
+{
+  "id": "myQuotes",
+  "label": "My Quotes",
+  "routeType": "Custom",
+  "urlPrefix": "quotes",
+  "activeViewId": "myQuotes"
+}

--- a/force-app/main/default/experiences/Community/routes/orderHistory.json
+++ b/force-app/main/default/experiences/Community/routes/orderHistory.json
@@ -1,0 +1,7 @@
+{
+  "id": "orderHistory",
+  "label": "Order History",
+  "routeType": "Custom",
+  "urlPrefix": "orders",
+  "activeViewId": "orderHistory"
+}

--- a/force-app/main/default/experiences/Community/routes/productCatalog.json
+++ b/force-app/main/default/experiences/Community/routes/productCatalog.json
@@ -1,0 +1,7 @@
+{
+  "id": "productCatalog",
+  "label": "Product Catalog",
+  "routeType": "Custom",
+  "urlPrefix": "catalog",
+  "activeViewId": "productCatalog"
+}

--- a/force-app/main/default/experiences/Community/themes/theme.json
+++ b/force-app/main/default/experiences/Community/themes/theme.json
@@ -1,0 +1,4 @@
+{
+  "themeName": "Lightning",
+  "defaultBrand": "default"
+}

--- a/force-app/main/default/experiences/Community/views/home.json
+++ b/force-app/main/default/experiences/Community/views/home.json
@@ -1,0 +1,14 @@
+{
+  "id": "home",
+  "label": "Home",
+  "viewType": "custom",
+  "regions": [
+    {
+      "id": "content",
+      "regionType": "main",
+      "components": [
+        { "id": "homeCatalog", "componentName": "c__productCatalog", "type": "LWC" }
+      ]
+    }
+  ]
+}

--- a/force-app/main/default/experiences/Community/views/myQuotes.json
+++ b/force-app/main/default/experiences/Community/views/myQuotes.json
@@ -1,0 +1,14 @@
+{
+  "id": "myQuotes",
+  "label": "My Quotes",
+  "viewType": "custom",
+  "regions": [
+    {
+      "id": "content",
+      "regionType": "main",
+      "components": [
+        { "id": "myQuotesComp", "componentName": "c__myQuotes", "type": "LWC" }
+      ]
+    }
+  ]
+}

--- a/force-app/main/default/experiences/Community/views/orderHistory.json
+++ b/force-app/main/default/experiences/Community/views/orderHistory.json
@@ -1,0 +1,14 @@
+{
+  "id": "orderHistory",
+  "label": "Order History",
+  "viewType": "custom",
+  "regions": [
+    {
+      "id": "content",
+      "regionType": "main",
+      "components": [
+        { "id": "orderHistoryComp", "componentName": "c__orderHistory", "type": "LWC" }
+      ]
+    }
+  ]
+}

--- a/force-app/main/default/experiences/Community/views/productCatalog.json
+++ b/force-app/main/default/experiences/Community/views/productCatalog.json
@@ -1,0 +1,14 @@
+{
+  "id": "productCatalog",
+  "label": "Product Catalog",
+  "viewType": "custom",
+  "regions": [
+    {
+      "id": "content",
+      "regionType": "main",
+      "components": [
+        { "id": "productCatalogComp", "componentName": "c__productCatalog", "type": "LWC" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- enable Communities scratch org feature
- add Experience Cloud site metadata and bundle with navigation, theme, and LWC pages
- document community activation steps

## Testing
- `npm test` *(fails: sfdx-lwc-jest: not found)*
- `sfdx force:source:deploy -p force-app/main/default/experiences -u MyScratchOrg` *(fails: command not found)*
- `sfdx force:user:permset:assign -n Community_User -u MyScratchOrg` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689b476dfbf08328b1318c708dcbe9dc