### PR TITLE
feat: secure PayGov payments with FLS checks

### DIFF
--- a/force-app/main/default/classes/OrderService.cls
+++ b/force-app/main/default/classes/OrderService.cls
@@ -546,11 +546,18 @@ public with sharing class OrderService {
     String paymentToken
   ) {
     try {
-      // Get customer information for payment processing
+      // Get customer information for payment processing with security
+      SecurityUtils.checkObjectReadable('Contact');
+      SecurityUtils.checkFieldReadAccess(
+        'Contact',
+        new List<String>{ 'Email', 'FirstName', 'LastName', 'AccountId' }
+      );
+
       Contact customer = [
         SELECT Email, FirstName, LastName, AccountId
         FROM Contact
         WHERE Id = :cart.Contact__c
+        WITH SECURITY_ENFORCED
         LIMIT 1
       ];
       
@@ -559,7 +566,8 @@ public with sharing class OrderService {
         getAgencyId(), // Federal agency ID from Custom Metadata
         'ORDER-' + System.currentTimeMillis(), // Unique order ID
         totalAmount,
-        customer.Email
+        customer.Email,
+        paymentToken
       );
       
       // Set payment request details

--- a/force-app/main/default/classes/OrderServiceTest.cls
+++ b/force-app/main/default/classes/OrderServiceTest.cls
@@ -1,0 +1,146 @@
+@IsTest
+private class OrderServiceTest {
+
+    class PayGovOrderMock implements HttpCalloutMock {
+        public HTTPResponse respond(HTTPRequest req) {
+            HttpResponse res = new HttpResponse();
+            res.setStatusCode(200);
+            res.setHeader('Content-Type','text/xml');
+            String body = '<?xml version="1.0" encoding="UTF-8"?>'
+                + '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pay="http://www.pay.gov/paygov">'
+                + '<soap:Body>'
+                + '<pay:InitiatePaymentResponse>'
+                + '<pay:TransactionId>PAYGOV_TEST_1</pay:TransactionId>'
+                + '<pay:RedirectUrl>https://pay.gov/redirect</pay:RedirectUrl>'
+                + '<pay:Status>INITIATED</pay:Status>'
+                + '</pay:InitiatePaymentResponse>'
+                + '</soap:Body>'
+                + '</soap:Envelope>';
+            res.setBody(body);
+            return res;
+        }
+    }
+
+    @TestSetup
+    static void setupData(){
+        // Account and Contact
+        Account acc = new Account(Name='Gov Account');
+        insert acc;
+        Contact con = new Contact(FirstName='John', LastName='Doe', Email='john.doe@example.com', AccountId=acc.Id);
+        insert con;
+
+        // User
+        Profile p = [SELECT Id FROM Profile WHERE Name='Standard User' LIMIT 1];
+        User u = new User(FirstName='John', LastName='Doe', Email='john.doe@example.com', Username='john.doe@example.com.test', Alias='jdoe', ProfileId=p.Id, TimeZoneSidKey='America/New_York', LocaleSidKey='en_US', EmailEncodingKey='UTF-8', LanguageLocaleKey='en_US', ContactId=con.Id);
+        insert u;
+
+        // Shipping address
+        Shipping_Address__c addr = new Shipping_Address__c(Account__c=acc.Id, Street__c='1 Main', City__c='City', State__c='CA', Postal_Code__c='90001', Country__c='USA');
+        insert addr;
+
+        // Product and pricebook
+        Product2 prod = new Product2(Name='Widget', ProductCode='W1', IsActive=true);
+        insert prod;
+        Id stdPb = Test.getStandardPricebookId();
+        PricebookEntry pbe = new PricebookEntry(Product2Id=prod.Id, Pricebook2Id=stdPb, UnitPrice=10, IsActive=true);
+        insert pbe;
+
+        // Cart with item
+        Cart__c cart1 = new Cart__c(Contact__c=con.Id, Status__c='Active');
+        insert cart1;
+        Cart_Item__c item1 = new Cart_Item__c(Cart__c=cart1.Id, Product__c=prod.Id, Quantity__c=1, Unit_Price__c=10, Line_Total__c=10);
+        insert item1;
+
+        // Second cart for bulk test
+        Cart__c cart2 = new Cart__c(Contact__c=con.Id, Status__c='Active');
+        insert cart2;
+        Cart_Item__c item2 = new Cart_Item__c(Cart__c=cart2.Id, Product__c=prod.Id, Quantity__c=2, Unit_Price__c=10, Line_Total__c=20);
+        insert item2;
+    }
+
+    @IsTest
+    static void testCreateOrderSuccessBulkAndHistory(){
+        User u = [SELECT Id FROM User WHERE Username='john.doe@example.com.test' LIMIT 1];
+        Shipping_Address__c addr = [SELECT Id FROM Shipping_Address__c LIMIT 1];
+        List<Cart__c> carts = [SELECT Id FROM Cart__c ORDER BY CreatedDate];
+
+        OrderService.CreateOrderRequest req1 = new OrderService.CreateOrderRequest();
+        req1.cartId = carts[0].Id;
+        req1.shippingAddressId = addr.Id;
+        req1.paymentToken = 'TOKEN-1';
+
+        OrderService.CreateOrderRequest req2 = new OrderService.CreateOrderRequest();
+        req2.cartId = carts[1].Id;
+        req2.shippingAddressId = addr.Id;
+        req2.paymentToken = 'TOKEN-2';
+
+        Test.setMock(HttpCalloutMock.class, new PayGovOrderMock());
+        List<OrderService.CreateOrderResponse> responses;
+        System.runAs(u){
+            Test.startTest();
+            responses = OrderService.createOrder(new List<OrderService.CreateOrderRequest>{req1, req2});
+            Test.stopTest();
+        }
+        System.assertEquals(2, responses.size(), 'Two responses expected');
+        for(OrderService.CreateOrderResponse r : responses){
+            System.assert(r.isSuccess, 'Order should succeed');
+            System.assertNotEquals(null, r.orderId, 'Order id expected');
+        }
+
+        // verify orders persisted and cart deleted
+        System.assertEquals(2, [SELECT count() FROM Order]);
+        System.assertEquals(0, [SELECT count() FROM Cart__c WHERE Id IN :new List<Id>{carts[0].Id, carts[1].Id}]);
+
+        // order history retrieval
+        System.runAs(u){
+            List<Order> orders = OrderService.getOrders();
+            System.assertEquals(2, orders.size(), 'Order history should return two orders');
+        }
+    }
+
+    @IsTest
+    static void testCreateOrderMissingPaymentToken(){
+        User u = [SELECT Id FROM User WHERE Username='john.doe@example.com.test' LIMIT 1];
+        Shipping_Address__c addr = [SELECT Id FROM Shipping_Address__c LIMIT 1];
+        Cart__c cart = [SELECT Id FROM Cart__c LIMIT 1];
+
+        OrderService.CreateOrderRequest req = new OrderService.CreateOrderRequest();
+        req.cartId = cart.Id;
+        req.shippingAddressId = addr.Id;
+        req.paymentToken = null; // missing token
+
+        Test.setMock(HttpCalloutMock.class, new PayGovOrderMock());
+        List<OrderService.CreateOrderResponse> responses;
+        System.runAs(u){
+            responses = OrderService.createOrder(new List<OrderService.CreateOrderRequest>{req});
+        }
+        System.assertEquals(1, responses.size());
+        System.assertEquals(false, responses[0].isSuccess);
+        System.assert(responses[0].message.contains('Payment Token'), 'Error should mention payment token');
+    }
+
+    @IsTest
+    static void testCreateOrderNoItems(){
+        // create cart without items
+        User u = [SELECT Id FROM User WHERE Username='john.doe@example.com.test' LIMIT 1];
+        Account acc = [SELECT Id FROM Account LIMIT 1];
+        Contact con = [SELECT Id FROM Contact LIMIT 1];
+        Cart__c emptyCart = new Cart__c(Contact__c=con.Id, Status__c='Active');
+        insert emptyCart;
+        Shipping_Address__c addr = [SELECT Id FROM Shipping_Address__c LIMIT 1];
+
+        OrderService.CreateOrderRequest req = new OrderService.CreateOrderRequest();
+        req.cartId = emptyCart.Id;
+        req.shippingAddressId = addr.Id;
+        req.paymentToken = 'TOKEN-3';
+
+        Test.setMock(HttpCalloutMock.class, new PayGovOrderMock());
+        List<OrderService.CreateOrderResponse> responses;
+        System.runAs(u){
+            responses = OrderService.createOrder(new List<OrderService.CreateOrderRequest>{req});
+        }
+        System.assertEquals(1, responses.size());
+        System.assertEquals(false, responses[0].isSuccess);
+        System.assert(responses[0].message.contains('Cart must contain at least one item'));
+    }
+}

--- a/force-app/main/default/classes/PayGovService.cls
+++ b/force-app/main/default/classes/PayGovService.cls
@@ -139,11 +139,15 @@ public with sharing class PayGovService {
         if (String.isBlank(request.customerEmail)) {
             throw new PayGovException('Customer email is required');
         }
-        
+
+        if (String.isBlank(request.paymentToken)) {
+            throw new PayGovException('Payment token is required');
+        }
+
         if (String.isBlank(request.agencyId)) {
             throw new PayGovException('Agency ID is required for Pay.gov integration');
         }
-        
+
         // Validate amount limits (Pay.gov typically has transaction limits)
         if (request.amount > 999999.99) {
             throw new PayGovException('Payment amount exceeds maximum allowed limit');
@@ -184,6 +188,7 @@ public with sharing class PayGovService {
             '<pay:Amount>' + request.amount + '</pay:Amount>' +
             '<pay:Currency>USD</pay:Currency>' +
             '<pay:CustomerEmail>' + String.escapeSingleQuotes(request.customerEmail) + '</pay:CustomerEmail>' +
+            '<pay:PaymentToken>' + String.escapeSingleQuotes(request.paymentToken) + '</pay:PaymentToken>' +
             '<pay:Description>' + String.escapeSingleQuotes(request.description) + '</pay:Description>' +
             '<pay:SuccessUrl>' + String.escapeSingleQuotes(request.successUrl) + '</pay:SuccessUrl>' +
             '<pay:CancelUrl>' + String.escapeSingleQuotes(request.cancelUrl) + '</pay:CancelUrl>' +
@@ -381,15 +386,20 @@ public with sharing class PayGovService {
         public String orderId;
         public Decimal amount;
         public String customerEmail;
+        /**
+         * Secure token representing the payment method. Never log this value.
+         */
+        public String paymentToken;
         public String description;
         public String successUrl;
         public String cancelUrl;
-        
-        public PayGovRequest(String agencyId, String orderId, Decimal amount, String customerEmail) {
+
+        public PayGovRequest(String agencyId, String orderId, Decimal amount, String customerEmail, String paymentToken) {
             this.agencyId = agencyId;
             this.orderId = orderId;
             this.amount = amount;
             this.customerEmail = customerEmail;
+            this.paymentToken = paymentToken;
         }
     }
     

--- a/force-app/main/default/classes/PayGovServiceTest.cls
+++ b/force-app/main/default/classes/PayGovServiceTest.cls
@@ -59,7 +59,8 @@ private class PayGovServiceTest {
             'TEST_AGENCY_123',
             'ORDER-' + System.currentTimeMillis(),
             100.00,
-            'jane.smith@agency.gov'
+            'jane.smith@agency.gov',
+            'TOKEN-ABC'
         );
         
         paymentRequest.description = 'Test Payment Description';
@@ -93,7 +94,8 @@ private class PayGovServiceTest {
             null, // Invalid agency ID
             'ORDER-TEST',
             100.00,
-            'jane.smith@agency.gov'
+            'jane.smith@agency.gov',
+            'TOKEN-ABC'
         );
 
         Test.startTest();
@@ -182,7 +184,8 @@ private class PayGovServiceTest {
                 'TEST_AGENCY',
                 'ORDER-TEST',
                 -10.00, // Invalid negative amount
-                'test@agency.gov'
+                'test@agency.gov',
+                'TOKEN-ABC'
             );
             PayGovService.initiatePayment(invalidRequest);
             System.assert(false, 'Exception should be thrown for negative amount');
@@ -196,14 +199,30 @@ private class PayGovServiceTest {
                 'TEST_AGENCY',
                 'ORDER-TEST',
                 1000000.00, // Exceeds limit
-                'test@agency.gov'
+                'test@agency.gov',
+                'TOKEN-ABC'
             );
             PayGovService.initiatePayment(limitRequest);
             System.assert(false, 'Exception should be thrown for amount exceeding limit');
         } catch (PayGovService.PayGovException e) {
             System.assert(e.getMessage().contains('maximum allowed limit'), 'Exception should mention limit');
         }
-        
+
+        // Test missing payment token
+        try {
+            PayGovService.PayGovRequest noTokenRequest = new PayGovService.PayGovRequest(
+                'TEST_AGENCY',
+                'ORDER-TEST',
+                50.00,
+                'test@agency.gov',
+                null
+            );
+            PayGovService.initiatePayment(noTokenRequest);
+            System.assert(false, 'Exception should be thrown for missing payment token');
+        } catch (PayGovService.PayGovException e) {
+            System.assert(e.getMessage().contains('Payment token'), 'Exception should mention payment token');
+        }
+
         Test.stopTest();
     }
 


### PR DESCRIPTION
## Summary
- require payment token for Pay.gov transactions and include in SOAP request
- enforce Contact FLS when preparing Pay.gov payments
- add comprehensive tests for PayGovService and OrderService

## Testing
- `npm test` *(fails: ./node_modules/.bin/sfdx-lwc-jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ce6ec8f088328ae9ff4c69a4d8f17