### PR TITLE
feat: harden record access checks

### DIFF
--- a/force-app/main/default/classes/SecurityUtils.cls
+++ b/force-app/main/default/classes/SecurityUtils.cls
@@ -427,12 +427,30 @@ public with sharing class SecurityUtils {
       );
     }
 
-    // Check if the user has read access to the object first
-    checkObjectReadable(sObjectName);
+    Schema.DescribeSObjectResult describeResult = getDescribe(sObjectName);
+    if (describeResult == null) {
+      throw new AuraHandledException('Security Error: Unknown SObject ' + sObjectName);
+    }
 
-    // Additional record-level access validation can be added here
-    // For now, we rely on Salesforce sharing rules and the 'with sharing' keyword
-    // This method provides a hook for future custom access control logic
+    if (!describeResult.isAccessible()) {
+      throw new AuraHandledException(
+        'Security Error: You do not have permission to access ' +
+        describeResult.getLabel() +
+        ' records.'
+      );
+    }
+
+    // Query record with sharing and FLS enforcement
+    String query =
+      'SELECT Id FROM ' +
+      describeResult.getName() +
+      ' WHERE Id = :recordId WITH SECURITY_ENFORCED LIMIT 1';
+    List<SObject> records = Database.query(query);
+    if (records.isEmpty()) {
+      throw new AuraHandledException(
+        'Security Error: Record not found or insufficient access.'
+      );
+    }
   }
 
   // ============================================================================

--- a/force-app/main/default/classes/SecurityUtilsTest.cls
+++ b/force-app/main/default/classes/SecurityUtilsTest.cls
@@ -200,7 +200,7 @@ public class SecurityUtilsTest {
     @isTest
     static void testInvalidFieldName() {
         List<String> invalidFields = new List<String>{'InvalidField__c'};
-        
+
         Test.startTest();
         try {
             SecurityUtils.checkFieldReadAccess('Product2', invalidFields);
@@ -209,6 +209,26 @@ public class SecurityUtilsTest {
             System.assert(true, 'Should handle invalid field name gracefully');
         }
         Test.stopTest();
+    }
+
+    @isTest
+    static void testValidateRecordAccess() {
+        Account acc1 = new Account(Name = 'Access OK');
+        Account acc2 = new Account(Name = 'Access Denied');
+        insert new List<Account>{ acc1, acc2 };
+        delete acc2;
+
+        Test.startTest();
+        SecurityUtils.validateRecordAccess(acc1.Id, 'Account');
+        Boolean threw = false;
+        try {
+            SecurityUtils.validateRecordAccess(acc2.Id, 'Account');
+        } catch (Exception e) {
+            threw = true;
+        }
+        Test.stopTest();
+
+        System.assert(threw, 'Should throw for inaccessible record');
     }
     
     @isTest

--- a/force-app/main/default/classes/StoreConnectSecurityUtil.cls
+++ b/force-app/main/default/classes/StoreConnectSecurityUtil.cls
@@ -7,11 +7,29 @@
  * @since 2024-12-01
  */
 public with sharing class StoreConnectSecurityUtil {
-    
+    // Cache global describes for performance
+    private static final Map<String, Schema.SObjectType> GLOBAL_DESCRIBE = Schema.getGlobalDescribe();
+    private static final Map<String, Schema.DescribeSObjectResult> DESCRIBE_CACHE =
+        new Map<String, Schema.DescribeSObjectResult>();
+
     /**
      * @description Custom exception for security violations
      */
     public class SecurityException extends Exception {}
+
+    /**
+     * Retrieves and caches describe information for an object
+     */
+    private static Schema.DescribeSObjectResult getDescribe(String objectName) {
+        if (!DESCRIBE_CACHE.containsKey(objectName)) {
+            Schema.SObjectType objType = GLOBAL_DESCRIBE.get(objectName);
+            if (objType == null) {
+                return null;
+            }
+            DESCRIBE_CACHE.put(objectName, objType.getDescribe());
+        }
+        return DESCRIBE_CACHE.get(objectName);
+    }
     
     /**
      * @description Sanitizes user input to prevent XSS and injection attacks
@@ -63,7 +81,44 @@ public with sharing class StoreConnectSecurityUtil {
             return false;
         }
     }
-    
+
+    /**
+     * @description Determines if a field potentially contains PII and therefore should be encrypted
+     * @param fieldName API name of the field
+     * @param objectName API name of the object
+     * @return Boolean indicating if encryption is recommended
+     */
+    public static Boolean requiresEncryption(String fieldName, String objectName) {
+        if (String.isBlank(fieldName) || String.isBlank(objectName)) {
+            return false;
+        }
+
+        Schema.DescribeSObjectResult describeResult = getDescribe(objectName);
+        if (describeResult == null) {
+            throw new SecurityException('Invalid object: ' + objectName);
+        }
+
+        Map<String, Schema.SObjectField> fieldMap = describeResult.fields.getMap();
+        if (!fieldMap.containsKey(fieldName)) {
+            throw new SecurityException('Invalid field: ' + fieldName);
+        }
+
+        Schema.DescribeFieldResult fieldDesc = fieldMap.get(fieldName).getDescribe();
+        String fieldNameUpper = fieldName.toUpperCase();
+        String fieldLabelUpper = fieldDesc.getLabel() != null ? fieldDesc.getLabel().toUpperCase() : '';
+
+        List<String> piiKeywords = new List<String>{
+            'EMAIL', 'SSN', 'SOCIAL', 'PHONE', 'ADDRESS', 'NAME', 'DOB', 'BIRTH'
+        };
+
+        for (String keyword : piiKeywords) {
+            if (fieldNameUpper.contains(keyword) || fieldLabelUpper.contains(keyword)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * @description Validates record access for bulk operations
      * @param records List of records to validate
@@ -73,24 +128,51 @@ public with sharing class StoreConnectSecurityUtil {
         if (records == null || records.isEmpty()) {
             return;
         }
-        
-        String objectType = records[0].getSObjectType().getDescribe().getName();
-        
+
+        String objectName = records[0].getSObjectType().getDescribe().getName();
+        for (SObject record : records) {
+            if (record.getSObjectType().getDescribe().getName() != objectName) {
+                throw new SecurityException('All records must be of the same SObject type');
+            }
+        }
+
         switch on operation.toUpperCase() {
             when 'CREATE' {
-                SecurityUtils.checkObjectCreateable(objectType);
+                SecurityUtils.checkObjectCreateable(objectName);
             }
             when 'READ' {
-                SecurityUtils.checkObjectReadable(objectType);
+                SecurityUtils.checkObjectReadable(objectName);
             }
             when 'UPDATE' {
-                SecurityUtils.checkObjectUpdateable(objectType);
+                SecurityUtils.checkObjectUpdateable(objectName);
             }
             when 'DELETE' {
-                SecurityUtils.checkObjectDeletable(objectType);
+                SecurityUtils.checkObjectDeletable(objectName);
             }
             when else {
                 throw new SecurityException('Invalid operation: ' + operation);
+            }
+        }
+
+        if (!operation.equalsIgnoreCase('CREATE')) {
+            Set<Id> recordIds = new Set<Id>();
+            for (SObject rec : records) {
+                if (rec.Id != null) {
+                    recordIds.add(rec.Id);
+                }
+            }
+            if (!recordIds.isEmpty()) {
+                String query =
+                    'SELECT Id FROM ' +
+                    objectName +
+                    ' WHERE Id IN :recordIds WITH SECURITY_ENFORCED';
+                Set<Id> accessibleIds =
+                    new Map<Id, SObject>(Database.query(query)).keySet();
+                if (accessibleIds.size() != recordIds.size()) {
+                    throw new SecurityException(
+                        'Security Error: One or more records are not accessible.'
+                    );
+                }
             }
         }
     }

--- a/force-app/main/default/classes/StoreConnectSecurityUtilTest.cls
+++ b/force-app/main/default/classes/StoreConnectSecurityUtilTest.cls
@@ -35,4 +35,38 @@ private class StoreConnectSecurityUtilTest {
         }
         System.assert(threwException, 'Method should throw exception when field does not exist');
     }
+
+    @IsTest
+    static void validateRecordAccess_allAccessible() {
+        Account a1 = new Account(Name = 'Accessible');
+        insert a1;
+
+        Test.startTest();
+        StoreConnectSecurityUtil.validateRecordAccess(new List<SObject>{ a1 }, 'READ');
+        Test.stopTest();
+
+        System.assert(true, 'Should not throw when all records are accessible');
+    }
+
+    @IsTest
+    static void validateRecordAccess_inaccessible() {
+        Account a1 = new Account(Name = 'A1');
+        Account a2 = new Account(Name = 'A2');
+        insert new List<Account>{ a1, a2 };
+        delete a2;
+
+        Boolean threw = false;
+        Test.startTest();
+        try {
+            StoreConnectSecurityUtil.validateRecordAccess(
+                new List<SObject>{ a1, new Account(Id = a2.Id) },
+                'READ'
+            );
+        } catch (StoreConnectSecurityUtil.SecurityException e) {
+            threw = true;
+        }
+        Test.stopTest();
+
+        System.assert(threw, 'Should throw when a record is not accessible');
+    }
 }


### PR DESCRIPTION
## Summary
- enforce record-level validation with WITH SECURITY_ENFORCED
- add PII detection and bulk record access verification
- expand unit tests for new security helpers

## Testing
- `npm test` *(fails: ./node_modules/.bin/sfdx-lwc-jest not found)*
- `npm ci` *(fails: connect ENETUNREACH 140.82.113.4:443)*

------
https://chatgpt.com/codex/tasks/task_e_689d6791d16c8328928e43549ee3586f